### PR TITLE
Allow passing arguments on command line

### DIFF
--- a/webdav.py
+++ b/webdav.py
@@ -761,7 +761,7 @@ if __name__ == '__main__':
     # or you can change your auth mode and file save format 
     userpwd = []
     if args.username and args.password:
-        userpwd.append(base64.b64encode("%s:%s" % (args.username, args.password)))
+        userpwd.append(base64.b64encode(("%s:%s" % (args.username, args.password)).encode()).decode())
     try:
         f = file('wdusers.conf', 'r')
         for uinfo in f.readlines():


### PR DESCRIPTION
Hello,
I really like your elegant single-file webdav server.
I've made some small changes if you're interested, this pull request is to add some optional startup arguments that can be passed in on the command line to set:
- webdav port
- root directory
- authentication
